### PR TITLE
fix/floating point precision for timestep

### DIFF
--- a/simulariumio/converter.py
+++ b/simulariumio/converter.py
@@ -223,6 +223,10 @@ class Converter:
         return True
 
     @staticmethod
+    def _format_timestep(number: float):
+        return float("%.4g" % number)
+
+    @staticmethod
     def _determine_plot_reader(plot_type: str = "scatter") -> [PlotReader]:
         """
         Return the plot reader to match the requested plot type

--- a/simulariumio/custom_converter.py
+++ b/simulariumio/custom_converter.py
@@ -41,7 +41,7 @@ class CustomConverter(Converter):
         totalSteps = len(input_data.agent_data.times)
         traj_info = {
             "version": 1,
-            "timeStepSize": (
+            "timeStepSize": Converter._format_timestep(
                 float(input_data.agent_data.times[1] - input_data.agent_data.times[0])
                 if totalSteps > 1
                 else 0.0

--- a/simulariumio/cytosim/cytosim_converter.py
+++ b/simulariumio/cytosim/cytosim_converter.py
@@ -332,7 +332,7 @@ class CytosimConverter(Converter):
         # trajectory info
         simularium_data["trajectoryInfo"] = {
             "version": 1,
-            "timeStepSize": (
+            "timeStepSize": Converter._format_timestep(
                 float(agent_data.times[1] - agent_data.times[0])
                 if totalSteps > 1
                 else 0.0

--- a/simulariumio/physicell/physicell_converter.py
+++ b/simulariumio/physicell/physicell_converter.py
@@ -162,7 +162,7 @@ class PhysicellConverter(Converter):
         totalSteps = agent_data.n_agents.shape[0]
         simularium_data["trajectoryInfo"] = {
             "version": 1,
-            "timeStepSize": input_data.timestep,
+            "timeStepSize": Converter._format_timestep(input_data.timestep),
             "totalSteps": totalSteps,
             "spatialUnitFactorMeters": unit_factor,
             "size": {

--- a/simulariumio/readdy/readdy_converter.py
+++ b/simulariumio/readdy/readdy_converter.py
@@ -177,7 +177,7 @@ class ReaddyConverter(Converter):
         totalSteps = agent_data.n_agents.shape[0]
         simularium_data["trajectoryInfo"] = {
             "version": 1,
-            "timeStepSize": float(input_data.timestep),
+            "timeStepSize": Converter._format_timestep(float(input_data.timestep)),
             "totalSteps": totalSteps,
             "spatialUnitFactorMeters": input_data.spatial_unit_factor_meters,
             "size": {

--- a/simulariumio/tests/converters/test_custom_converter.py
+++ b/simulariumio/tests/converters/test_custom_converter.py
@@ -620,7 +620,7 @@ from simulariumio.tests.conftest import three_default_agents
                 spatial_unit_factor_meters=10.0,
                 box_size=np.array([1000.0, 1000.0, 1000.0]),
                 agent_data=AgentData(
-                    times=1.0 * np.array(list(range(3))),
+                    times=np.array([0.0, 1.00001, 2.00001]),
                     n_agents=np.array(3 * [3]),
                     viz_types=1001.0 * np.ones(shape=(3, 3)),
                     unique_ids=np.array(
@@ -843,7 +843,7 @@ from simulariumio.tests.conftest import three_default_agents
                         },
                         {
                             "frameNumber": 1,
-                            "time": 1.0,
+                            "time": 1.00001,
                             "data": [
                                 1001.0,
                                 1.0,
@@ -961,7 +961,7 @@ from simulariumio.tests.conftest import three_default_agents
                         },
                         {
                             "frameNumber": 2,
-                            "time": 2.0,
+                            "time": 2.00001,
                             "data": [
                                 1001.0,
                                 1.0,


### PR DESCRIPTION
This is a fix for floating point precision errors in the timestep that were a problem for the front end time bar's calculations (Dan is adding a check there too). 


## Pull request recommendations:
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
