### PR TITLE
Feature/default camera fov 75

### DIFF
--- a/examples/Tutorial_custom.ipynb
+++ b/examples/Tutorial_custom.ipynb
@@ -82,7 +82,7 @@
     "    * Default: np.array(\\[0.0, 1.0, 0.0\\])\n",
     "* **fov_degrees**: *float (optional)*\n",
     "    * the angle defining the extent of the 3D world that is seen from bottom to top of the camera view\n",
-    "    * Default: 50.0\n",
+    "    * Default: 75.0\n",
     "\n",
     "`AgentData` contains the following:\n",
     "* **times** : *np.ndarray (shape = [timesteps])*\n",

--- a/examples/Tutorial_cytosim.ipynb
+++ b/examples/Tutorial_cytosim.ipynb
@@ -92,7 +92,7 @@
     "    * Default: np.array(\\[0.0, 1.0, 0.0\\])\n",
     "* **fov_degrees**: *float (optional)*\n",
     "    * the angle defining the extent of the 3D world that is seen from bottom to top of the camera view\n",
-    "    * Default: 50.0\n",
+    "    * Default: 75.0\n",
     "    \n",
     "`CytosimObjectInfo` contains the following:\n",
     "* **filepath** : *str*\n",

--- a/examples/Tutorial_mcell.ipynb
+++ b/examples/Tutorial_mcell.ipynb
@@ -82,7 +82,7 @@
     "    * Default: np.array(\\[0.0, 1.0, 0.0\\])\n",
     "* **fov_degrees**: *float (optional)*\n",
     "    * the angle defining the extent of the 3D world that is seen from bottom to top of the camera view\n",
-    "    * Default: 50.0"
+    "    * Default: 75.0"
    ]
   },
   {

--- a/examples/Tutorial_medyan.ipynb
+++ b/examples/Tutorial_medyan.ipynb
@@ -88,7 +88,7 @@
     "    * Default: np.array(\\[0.0, 1.0, 0.0\\])\n",
     "* **fov_degrees**: *float (optional)*\n",
     "    * the angle defining the extent of the 3D world that is seen from bottom to top of the camera view\n",
-    "    * Default: 50.0"
+    "    * Default: 75.0"
    ]
   },
   {

--- a/examples/Tutorial_physicell.ipynb
+++ b/examples/Tutorial_physicell.ipynb
@@ -91,7 +91,7 @@
     "    * Default: np.array(\\[0.0, 1.0, 0.0\\])\n",
     "* **fov_degrees**: *float (optional)*\n",
     "    * the angle defining the extent of the 3D world that is seen from bottom to top of the camera view\n",
-    "    * Default: 50.0\n",
+    "    * Default: 75.0\n",
     "\n",
     "`UnitData` contains the following:\n",
     "* **name**: *str*\n",

--- a/examples/Tutorial_readdy.ipynb
+++ b/examples/Tutorial_readdy.ipynb
@@ -96,7 +96,7 @@
     "    * Default: np.array(\\[0.0, 1.0, 0.0\\])\n",
     "* **fov_degrees**: *float (optional)*\n",
     "    * the angle defining the extent of the 3D world that is seen from bottom to top of the camera view\n",
-    "    * Default: 50.0\n",
+    "    * Default: 75.0\n",
     "\n",
     "`UnitData` contains the following:\n",
     "* **name**: *str*\n",

--- a/examples/Tutorial_smoldyn.ipynb
+++ b/examples/Tutorial_smoldyn.ipynb
@@ -96,7 +96,7 @@
     "    * Default: np.array(\\[0.0, 1.0, 0.0\\])\n",
     "* **fov_degrees**: *float (optional)*\n",
     "    * the angle defining the extent of the 3D world that is seen from bottom to top of the camera view\n",
-    "    * Default: 50.0\n",
+    "    * Default: 75.0\n",
     "\n",
     "`UnitData` contains the following:\n",
     "* **name**: *str*\n",

--- a/examples/Tutorial_springsalad.ipynb
+++ b/examples/Tutorial_springsalad.ipynb
@@ -73,7 +73,7 @@
     "    * Default: np.array(\\[0.0, 1.0, 0.0\\])\n",
     "* **fov_degrees**: *float (optional)*\n",
     "    * the angle defining the extent of the 3D world that is seen from bottom to top of the camera view\n",
-    "    * Default: 50.0"
+    "    * Default: 75.0"
    ]
   },
   {

--- a/file_format.md
+++ b/file_format.md
@@ -16,7 +16,7 @@ JSON files accepted by the simularium-viewer contain the following data in JSON 
     * position X, Y, Z - 3D position of the camera itself (default = [0, 0, 120])
     * lookAtPoint X, Y, Z - position the camera looks at (default = [0, 0, 0])
     * upVector X, Y, Z - the vector that defines which direction is "up" in the camera's view (default = [0, 1, 0])
-    * fovDegrees - the angle defining the extent of the 3D world that is seen from bottom to top of the camera view (default = 50)
+    * fovDegrees - the angle defining the extent of the 3D world that is seen from bottom to top of the camera view (default = 75)
   * type mapping - for each agent type ID in the trajectory, information about how to display and render it:
     * name - the type name to display for all agents of this type. Optionally, this name can be followed by a hash and state tags for the agent’s current state delimited with underscores
       * ex: "actin#barbed_ATP_1" is parsed as agent type "actin" in states "barbed", "ATP", and "1"
@@ -105,7 +105,7 @@ JSON files accepted by the simularium-viewer contain the following data in JSON 
                 "y" : 1,
                 "z" : 0
             },
-            "fovDegrees" : 50,
+            "fovDegrees" : 75,
         },
         // agent display data
         "typeMapping": {

--- a/simulariumio/data_objects/camera_data.py
+++ b/simulariumio/data_objects/camera_data.py
@@ -24,7 +24,7 @@ class CameraData:
         position: np.ndarray = np.array([0.0, 0.0, 120.0]),
         look_at_position: np.ndarray = np.zeros(3),
         up_vector: np.ndarray = np.array([0.0, 1.0, 0.0]),
-        fov_degrees: float = 50.0,
+        fov_degrees: float = 75.0,
     ):
         """
         This object holds parameters that define
@@ -45,7 +45,7 @@ class CameraData:
         fov_degrees : float (optional)
             the angle defining the extent of the 3D world
             that is seen from bottom to top of the camera view
-            Default: 50.0
+            Default: 75.0
         """
         self.position = position
         self.look_at_position = look_at_position

--- a/simulariumio/data_objects/meta_data.py
+++ b/simulariumio/data_objects/meta_data.py
@@ -42,7 +42,7 @@ class MetaData:
                 position=[0,0,120],
                 look_at_position=[0,0,0],
                 up_vector=[0,1,0],
-                fov_degrees=50
+                fov_degrees=75
             )
         scale_factor : float (optional)
             A multiplier for the scene, use if

--- a/simulariumio/file_converter.py
+++ b/simulariumio/file_converter.py
@@ -66,7 +66,7 @@ class FileConverter(TrajectoryConverter):
                 "position": {"x": 0, "y": 0, "z": 120},
                 "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                 "upVector": {"x": 0, "y": 1, "z": 0},
-                "fovDegrees": 50.0,
+                "fovDegrees": 75.0,
             }
             data["trajectoryInfo"]["version"] = 2
         print(f"Updated TrajectoryInfo v1 -> v{self.current_trajectory_info_version}")

--- a/simulariumio/mcell/mcell_data.py
+++ b/simulariumio/mcell/mcell_data.py
@@ -66,7 +66,7 @@ class McellData:
                 position=[0,0,120],
                 look_at_position=[0,0,0],
                 up_vector=[0,1,0],
-                fov_degrees=50
+                fov_degrees=75
             )
         scale_factor : float (optional)
             A multiplier for the scene, use if

--- a/simulariumio/springsalad/springsalad_data.py
+++ b/simulariumio/springsalad/springsalad_data.py
@@ -49,7 +49,7 @@ class SpringsaladData:
                 position=[0,0,120],
                 look_at_position=[0,0,0],
                 up_vector=[0,1,0],
-                fov_degrees=50
+                fov_degrees=75
             )
         scale_factor : float (optional)
             A multiplier for the scene, use if

--- a/simulariumio/tests/converters/test_cytosim_converter.py
+++ b/simulariumio/tests/converters/test_cytosim_converter.py
@@ -49,7 +49,7 @@ from simulariumio import MetaData
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {"0": {"name": "fiber"}},
                 },
@@ -356,7 +356,7 @@ from simulariumio import MetaData
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "1": {"name": "microtubule"},

--- a/simulariumio/tests/converters/test_mcell_converter.py
+++ b/simulariumio/tests/converters/test_mcell_converter.py
@@ -36,7 +36,7 @@ from simulariumio.mcell import McellConverter, McellData
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "0": {"name": "b"},

--- a/simulariumio/tests/converters/test_medyan_converter.py
+++ b/simulariumio/tests/converters/test_medyan_converter.py
@@ -49,7 +49,7 @@ from simulariumio import MetaData
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "0": {"name": "Actin"},
@@ -422,7 +422,7 @@ from simulariumio import MetaData
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "0": {"name": "Actin"},

--- a/simulariumio/tests/converters/test_physicell_converter.py
+++ b/simulariumio/tests/converters/test_physicell_converter.py
@@ -39,7 +39,7 @@ from simulariumio import MetaData
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "0": {"name": "cell 1#phase 4"},

--- a/simulariumio/tests/converters/test_readdy_converter.py
+++ b/simulariumio/tests/converters/test_readdy_converter.py
@@ -43,7 +43,7 @@ from simulariumio import UnitData, MetaData
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {"2": {"name": "C"}, "1": {"name": "B"}},
                 },

--- a/simulariumio/tests/converters/test_smoldyn_converter.py
+++ b/simulariumio/tests/converters/test_smoldyn_converter.py
@@ -50,7 +50,7 @@ from simulariumio import MetaData, UnitData
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "0": {"name": "S"},
@@ -227,7 +227,7 @@ from simulariumio import MetaData, UnitData
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "0": {"name": "green(solution)"},

--- a/simulariumio/tests/converters/test_springsalad_converter.py
+++ b/simulariumio/tests/converters/test_springsalad_converter.py
@@ -37,7 +37,7 @@ from simulariumio.springsalad import SpringsaladConverter, SpringsaladData
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "0": {"name": "A"},

--- a/simulariumio/tests/converters/test_trajectory_converter.py
+++ b/simulariumio/tests/converters/test_trajectory_converter.py
@@ -40,7 +40,7 @@ from simulariumio.tests.conftest import three_default_agents
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "0": {"name": "C"},
@@ -761,7 +761,7 @@ from simulariumio.tests.conftest import three_default_agents
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "0": {"name": "H"},

--- a/simulariumio/tests/filters/test_add_agents_filter.py
+++ b/simulariumio/tests/filters/test_add_agents_filter.py
@@ -32,7 +32,7 @@ from simulariumio.tests.conftest import three_default_agents
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "0": {"name": "C"},

--- a/simulariumio/tests/filters/test_every_nth_agent_filter.py
+++ b/simulariumio/tests/filters/test_every_nth_agent_filter.py
@@ -41,7 +41,7 @@ from simulariumio.filters import EveryNthAgentFilter
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "1": {"name": "microtubule"},

--- a/simulariumio/tests/filters/test_every_nth_subpoint_filter.py
+++ b/simulariumio/tests/filters/test_every_nth_subpoint_filter.py
@@ -37,7 +37,7 @@ from simulariumio.filters import EveryNthSubpointFilter
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "1": {"name": "microtubule"},

--- a/simulariumio/tests/filters/test_every_nth_timestep_filter.py
+++ b/simulariumio/tests/filters/test_every_nth_timestep_filter.py
@@ -32,7 +32,7 @@ from simulariumio.filters import EveryNthTimestepFilter
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "1": {"name": "microtubule"},

--- a/simulariumio/tests/filters/test_multiply_space_filter.py
+++ b/simulariumio/tests/filters/test_multiply_space_filter.py
@@ -32,7 +32,7 @@ from simulariumio.filters import MultiplySpaceFilter
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "1": {"name": "microtubule"},

--- a/simulariumio/tests/filters/test_multiply_time_filter.py
+++ b/simulariumio/tests/filters/test_multiply_time_filter.py
@@ -34,7 +34,7 @@ from simulariumio.tests.conftest import test_scatter_plot
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "1": {"name": "microtubule"},

--- a/simulariumio/tests/filters/test_reorder_agents_filter.py
+++ b/simulariumio/tests/filters/test_reorder_agents_filter.py
@@ -37,7 +37,7 @@ from simulariumio.filters import ReorderAgentsFilter
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "1": {"name": "motor complex"},

--- a/simulariumio/tests/filters/test_transform_spatial_axes_filter.py
+++ b/simulariumio/tests/filters/test_transform_spatial_axes_filter.py
@@ -32,7 +32,7 @@ from simulariumio.filters import TransformSpatialAxesFilter
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "1": {"name": "microtubule"},

--- a/simulariumio/tests/filters/test_translate_filter.py
+++ b/simulariumio/tests/filters/test_translate_filter.py
@@ -34,7 +34,7 @@ from simulariumio.filters import TranslateFilter
                         "position": {"x": 0, "y": 0, "z": 120},
                         "lookAtPosition": {"x": 0, "y": 0, "z": 0},
                         "upVector": {"x": 0, "y": 1, "z": 0},
-                        "fovDegrees": 50.0,
+                        "fovDegrees": 75.0,
                     },
                     "typeMapping": {
                         "1": {"name": "microtubule"},


### PR DESCRIPTION
Problem
=======
The Simularium Viewer's default camera FOV is 75 and SimulariumIO's was 50.
Resolves https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1412 

Solution
========
Update SimulariumIO's default FOV to 75.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update
- [ ] This change requires updated or new tests

Change summary:
---------------
* change default FOV in CameraData
* update tests and documentation

Keyfiles:
-----------------------
1. simulariumio/data_objects/camera_data.py - update default FOV for a CameraData, which holds camera settings
2. simulariumio/file_converter.py - update default FOV when older file versions are read in
3. file_format.md - update file format documentation
4. jupyter notebooks and tests - update FOV
