### PR TITLE
Change references to master branch to main

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,7 +3,7 @@ name: Documentation
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   docs:
@@ -34,6 +34,6 @@ jobs:
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-        BASE_BRANCH: master # The branch the action should deploy from.
+        BASE_BRANCH: main # The branch the action should deploy from.
         BRANCH: gh-pages # The branch the action should deploy to.
         FOLDER: docs/_build/html/ # The folder the action should deploy.

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -1,9 +1,9 @@
-name: Build Master
+name: Build Main
 
 on:
   push:
     branches:
-      - master
+      - main
   schedule:
     # <minute [0,59]> <hour [0,23]> <day of the month [1,31]> <month of the year [1,12]> <day of the week [0,6]>
     # https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@main
       with:
         user: aicspypi
         password: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository is part of the Simularium project ([simularium.allencell.org](ht
 
 [![Build Status](https://github.com/allen-cell-animated/simulariumio/workflows/Build%20Master/badge.svg)](https://github.com/allen-cell-animated/simulariumio/actions)
 [![Documentation](https://github.com/allen-cell-animated/simulariumio/workflows/Documentation/badge.svg)](https://allen-cell-animated.github.io/simulariumio)
-[![Code Coverage](https://codecov.io/gh/allen-cell-animated/simulariumio/branch/main/graph/badge.svg)](https://codecov.io/gh/allen-cell-animated/simulariumio)
+[![Code Coverage](https://codecov.io/gh/allen-cell-animated/simulariumio/branch/master/graph/badge.svg)](https://codecov.io/gh/allen-cell-animated/simulariumio)
 
 Simulariumio converts simulation outputs to the format consumed by the [Simularium viewer](https://simularium.allencell.org/).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository is part of the Simularium project ([simularium.allencell.org](ht
 
 [![Build Status](https://github.com/allen-cell-animated/simulariumio/workflows/Build%20Master/badge.svg)](https://github.com/allen-cell-animated/simulariumio/actions)
 [![Documentation](https://github.com/allen-cell-animated/simulariumio/workflows/Documentation/badge.svg)](https://allen-cell-animated.github.io/simulariumio)
-[![Code Coverage](https://codecov.io/gh/allen-cell-animated/simulariumio/branch/master/graph/badge.svg)](https://codecov.io/gh/allen-cell-animated/simulariumio)
+[![Code Coverage](https://codecov.io/gh/allen-cell-animated/simulariumio/branch/main/graph/badge.svg)](https://codecov.io/gh/allen-cell-animated/simulariumio)
 
 Simulariumio converts simulation outputs to the format consumed by the [Simularium viewer](https://simularium.allencell.org/).
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -38,7 +38,7 @@ Or download the `tarball`_:
 
 .. code-block:: console
 
-    $ curl  -OL https://github.com/allen-cell-animated/simulariumio/tarball/master
+    $ curl  -OL https://github.com/allen-cell-animated/simulariumio/tarball/main
 
 Once you have a copy of the source, you can install it with:
 
@@ -48,4 +48,4 @@ Once you have a copy of the source, you can install it with:
 
 
 .. _Github repo: https://github.com/allen-cell-animated/simulariumio
-.. _tarball: https://github.com/allen-cell-animated/simulariumio/tarball/master
+.. _tarball: https://github.com/allen-cell-animated/simulariumio/tarball/main


### PR DESCRIPTION
Problem
=======
I changed the master branch for simularium-website, viewer, and simulariumio to `main` but there are references to `master` in this repo.

Solution
========
I replaced all the references to this repository's master branch with main.

FYI, all GitHub URLs to a repo's master branch (like https://github.com/allen-cell-animated/simulariumio/blob/master/examples/Tutorial_custom.ipynb) automatically redirect to the main branch, so it's not a worry. But I swapped them out in _docs/installation.rst_ anyway. 

Steps to Verify:
----------------
1. Pull this branch and do a global search for `master` and verify that all the occurrences that need updating to `main` are updated.
