### PR TITLE
add pint to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ dev_requirements = [
 requirements = [
     "numpy>=1.16",
     "pandas>=1.1.2",
+    "pint>=0.17",
 ]
 
 extra_requirements = {


### PR DESCRIPTION
Problem
=======
resolves #49 
When I installed simulariumio 1.1.0 I got the following error
I'm not sure why this didn't show up in the build/test github actions 

```bash  
File "/Users/meganriel-mehan/anaconda3/envs/autopack/lib/python3.8/site-packages/simulariumio/data_objects/unit_data.py", line 6, in <module>
 from pint import UnitRegistry
ModuleNotFoundError: No module named 'pint'`
```
Solution
========
Add pint to the requirements 

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


