### PR TITLE
Fix/require display type

### DIFF
--- a/simulariumio/data_objects/agent_data.py
+++ b/simulariumio/data_objects/agent_data.py
@@ -14,6 +14,7 @@ from ..constants import (
     V1_SPATIAL_BUFFER_STRUCT,
     VIZ_TYPE,
     BUFFER_SIZE_INC,
+    DISPLAY_TYPE,
 )
 from .dimension_data import DimensionData
 from .display_data import DisplayData
@@ -178,22 +179,34 @@ class AgentData:
         last_tid = 0
         for time_index in range(total_steps):
             for agent_index in range(len(self.types[time_index])):
-                tn = self.types[time_index][agent_index]
-                if len(tn) == 0:
+                type_name = self.types[time_index][agent_index]
+                if len(type_name) == 0:
                     continue
-                if tn not in type_id_mapping:
+                if type_name not in type_id_mapping:
                     tid = last_tid
                     last_tid += 1
-                    type_id_mapping[tn] = tid
-                    type_name_mapping[str(tid)] = {"name": tn}
+                    type_id_mapping[type_name] = tid
+                    type_name_mapping[str(tid)] = {"name": type_name}
+                    has_subpoints = self.n_subpoints[time_index][agent_index] > 0
                     if (
-                        tn in self.display_data
-                        and not self.display_data[tn].is_default()
+                        type_name in self.display_data
+                        and not self.display_data[type_name].is_default()
                     ):
-                        type_name_mapping[str(tid)]["geometry"] = dict(
-                            self.display_data[tn]
+                        self.display_data[type_name].check_set_default_display_type(
+                            has_subpoints
                         )
-                type_ids[time_index][agent_index] = type_id_mapping[tn]
+                        type_name_mapping[str(tid)]["geometry"] = dict(
+                            self.display_data[type_name]
+                        )
+                    else:
+                        type_name_mapping[str(tid)]["geometry"] = {
+                            "displayType": (
+                                DISPLAY_TYPE.FIBER
+                                if has_subpoints
+                                else DISPLAY_TYPE.SPHERE
+                            ).name,
+                        }
+                type_ids[time_index][agent_index] = type_id_mapping[type_name]
         return type_ids, type_name_mapping
 
     @staticmethod
@@ -241,7 +254,7 @@ class AgentData:
         """
         bundle_data = buffer_data["spatialData"]["bundleData"]
         dimensions = AgentData._get_buffer_data_dimensions(buffer_data)
-        print(f"original dim = {dimensions.to_string()}")
+        print(f"original dim = {dimensions}")
         agent_data = AgentData.from_dimensions(dimensions)
         type_ids = np.zeros((dimensions.total_steps, dimensions.max_agents))
         for time_index in range(dimensions.total_steps):
@@ -436,7 +449,6 @@ class AgentData:
         """
         print(f"increase buffer {axis}")
         current_dimensions = self.get_dimensions()
-        # raise Exception(added_dimensions.to_string())
         new_dimensions = added_dimensions.add(current_dimensions, axis)
         current_types = copy.deepcopy(self.types)
         result = AgentData.from_dimensions(new_dimensions)

--- a/simulariumio/data_objects/dimension_data.py
+++ b/simulariumio/data_objects/dimension_data.py
@@ -65,7 +65,7 @@ class DimensionData:
             max_subpoints=self.max_subpoints + added_dimensions.max_subpoints,
         )
 
-    def to_string(self):
+    def __str__(self):
         return (
             f"{self.total_steps} timesteps X {self.max_agents} agents "
             f"X {self.max_subpoints} subpoints"

--- a/simulariumio/data_objects/display_data.py
+++ b/simulariumio/data_objects/display_data.py
@@ -80,15 +80,23 @@ class DisplayData:
             self.display_type == DISPLAY_TYPE.NONE and not self.url and not self.color
         )
 
-    def to_string(self):
+    def check_set_default_display_type(self, has_subpoints):
+        """
+        If the display type hasn't been specified, set it to a default
+        based on whether the agent has subpoints
+        """
+        if self.display_type != DISPLAY_TYPE.NONE:
+            return
+        self.display_type = DISPLAY_TYPE.FIBER if has_subpoints else DISPLAY_TYPE.SPHERE
+
+    def __str__(self):
         return (
             f"{self.display_type.value}: url={self.url}, color={self.color} "
             f"is_default? {self.is_default()}"
         )
 
     def __iter__(self):
-        if self.display_type != DISPLAY_TYPE.NONE:
-            yield "displayType", self.display_type.value
+        yield "displayType", self.display_type.value
         if self.url:
             yield "url", self.url
         if self.color:

--- a/simulariumio/data_objects/unit_data.py
+++ b/simulariumio/data_objects/unit_data.py
@@ -63,7 +63,7 @@ class UnitData:
         self._quantity *= multiplier
         self._update_units()
 
-    def to_string(self):
+    def __str__(self):
         """
         get a string for the units
         """

--- a/simulariumio/tests/conftest.py
+++ b/simulariumio/tests/conftest.py
@@ -22,8 +22,18 @@ from simulariumio.constants import DISPLAY_TYPE
 
 def default_agents_type_mapping() -> Dict[str, Any]:
     return {
-        "0": {"name": "C"},
-        "1": {"name": "U"},
+        "0": {
+            "name": "C",
+            "geometry": {
+                "displayType": "SPHERE",
+            },
+        },
+        "1": {
+            "name": "U",
+            "geometry": {
+                "displayType": "SPHERE",
+            },
+        },
         "2": {
             "name": "L",
             "geometry": {
@@ -39,7 +49,12 @@ def default_agents_type_mapping() -> Dict[str, Any]:
                 "color": "#000000",
             },
         },
-        "4": {"name": "O"},
+        "4": {
+            "name": "O",
+            "geometry": {
+                "displayType": "SPHERE",
+            },
+        },
         "5": {
             "name": "Y",
             "geometry": {
@@ -50,6 +65,7 @@ def default_agents_type_mapping() -> Dict[str, Any]:
         "6": {
             "name": "W",
             "geometry": {
+                "displayType": "SPHERE",
                 "color": "#666",
             },
         },

--- a/simulariumio/tests/converters/test_cytosim_converter.py
+++ b/simulariumio/tests/converters/test_cytosim_converter.py
@@ -435,15 +435,29 @@ from simulariumio.constants import (
                     "typeMapping": {
                         "0": {
                             "name": "fiber1",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
                         },
                         "1": {
                             "name": "actin",
                             "geometry": {
+                                "displayType": "FIBER",
                                 "color": "#ffc100",
                             },
                         },
-                        "2": {"name": "aster"},
-                        "3": {"name": "vesicle"},
+                        "2": {
+                            "name": "aster",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "3": {
+                            "name": "vesicle",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
                         "4": {
                             "name": "kinesin",
                             "geometry": {
@@ -452,8 +466,18 @@ from simulariumio.constants import (
                                 "color": "#0080ff",
                             },
                         },
-                        "5": {"name": "dynein"},
-                        "6": {"name": "motor complex"},
+                        "5": {
+                            "name": "dynein",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "6": {
+                            "name": "motor complex",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
                     },
                 },
                 "spatialData": {

--- a/simulariumio/tests/converters/test_mcell_converter.py
+++ b/simulariumio/tests/converters/test_mcell_converter.py
@@ -73,10 +73,16 @@ from simulariumio.constants import (
                         "fovDegrees": DEFAULT_CAMERA_SETTINGS.FOV_DEGREES,
                     },
                     "typeMapping": {
-                        "0": {"name": "b"},
+                        "0": {
+                            "name": "b",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
                         "1": {
                             "name": "Transporter",
                             "geometry": {
+                                "displayType": "SPHERE",
                                 "color": "#ff1493",
                             },
                         },
@@ -223,8 +229,5 @@ from simulariumio.constants import (
 def test_mcell_converter(trajectory, expected_data):
     converter = McellConverter(trajectory)
     buffer_data = converter._read_trajectory_data(converter._data)
-    assert (
-        expected_data["trajectoryInfo"]["typeMapping"]
-        == buffer_data["trajectoryInfo"]["typeMapping"]
-    )
+    expected_data == buffer_data
     assert converter._check_agent_ids_are_unique_per_frame(buffer_data)

--- a/simulariumio/tests/converters/test_medyan_converter.py
+++ b/simulariumio/tests/converters/test_medyan_converter.py
@@ -72,18 +72,35 @@ from simulariumio.constants import DEFAULT_CAMERA_SETTINGS, CURRENT_VERSION
                         "0": {
                             "name": "Actin",
                             "geometry": {
+                                "displayType": "FIBER",
                                 "color": "#d71f5f",
                             },
                         },
-                        "1": {"name": "linker0"},
+                        "1": {
+                            "name": "linker0",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
                         "2": {
                             "name": "Xlink",
                             "geometry": {
+                                "displayType": "FIBER",
                                 "color": "#0080ff",
                             },
                         },
-                        "3": {"name": "linker2"},
-                        "4": {"name": "motor1"},
+                        "3": {
+                            "name": "linker2",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "4": {
+                            "name": "motor1",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
                     },
                 },
                 "spatialData": {
@@ -468,22 +485,47 @@ from simulariumio.constants import DEFAULT_CAMERA_SETTINGS, CURRENT_VERSION
                         "0": {
                             "name": "Actin",
                             "geometry": {
+                                "displayType": "FIBER",
                                 "color": "#ff1493",
                             },
                         },
                         "1": {
                             "name": "Xlink0",
                             "geometry": {
+                                "displayType": "FIBER",
                                 "color": "#0080ff",
                             },
                         },
-                        "2": {"name": "Xlink0 End"},
+                        "2": {
+                            "name": "Xlink0 End",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
                         "3": {
                             "name": "Xlink1",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
                         },
-                        "4": {"name": "Xlink1 End"},
-                        "5": {"name": "linker2"},
-                        "6": {"name": "motor1"},
+                        "4": {
+                            "name": "Xlink1 End",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "5": {
+                            "name": "linker2",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "6": {
+                            "name": "motor1",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
                     },
                 },
                 "spatialData": {

--- a/simulariumio/tests/converters/test_physicell_converter.py
+++ b/simulariumio/tests/converters/test_physicell_converter.py
@@ -63,10 +63,16 @@ from simulariumio.constants import DEFAULT_CAMERA_SETTINGS, CURRENT_VERSION
                         "fovDegrees": DEFAULT_CAMERA_SETTINGS.FOV_DEGREES,
                     },
                     "typeMapping": {
-                        "0": {"name": "cell1#interphase"},
+                        "0": {
+                            "name": "cell1#interphase",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
                         "1": {
                             "name": "Cancer cell#phase4",
                             "geometry": {
+                                "displayType": "SPHERE",
                                 "color": "#0080ff",
                             },
                         },

--- a/simulariumio/tests/converters/test_readdy_converter.py
+++ b/simulariumio/tests/converters/test_readdy_converter.py
@@ -83,6 +83,7 @@ from simulariumio.constants import (
                         "0": {
                             "name": "C",
                             "geometry": {
+                                "displayType": "SPHERE",
                                 "color": "#0080ff",
                             },
                         },

--- a/simulariumio/tests/converters/test_smoldyn_converter.py
+++ b/simulariumio/tests/converters/test_smoldyn_converter.py
@@ -91,10 +91,16 @@ from simulariumio.constants import (
                         "1": {
                             "name": "E",
                             "geometry": {
+                                "displayType": "SPHERE",
                                 "color": "#0080ff",
                             },
                         },
-                        "2": {"name": "ES"},
+                        "2": {
+                            "name": "ES",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
                     },
                 },
                 "spatialData": {
@@ -304,10 +310,16 @@ from simulariumio.constants import (
                         "0": {
                             "name": "Green",
                             "geometry": {
+                                "displayType": "SPHERE",
                                 "color": "#dfdacd",
                             },
                         },
-                        "1": {"name": "red(solution)"},
+                        "1": {
+                            "name": "red(solution)",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
                     },
                 },
                 "spatialData": {

--- a/simulariumio/tests/converters/test_springsalad_converter.py
+++ b/simulariumio/tests/converters/test_springsalad_converter.py
@@ -86,12 +86,28 @@ from simulariumio.constants import (
                         "1": {
                             "name": "B",
                             "geometry": {
+                                "displayType": "SPHERE",
                                 "color": "#0080ff",
                             },
                         },
-                        "2": {"name": "GRAY"},
-                        "3": {"name": "CYAN"},
-                        "4": {"name": "BLUE"},
+                        "2": {
+                            "name": "GRAY",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "3": {
+                            "name": "CYAN",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "4": {
+                            "name": "BLUE",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
                     },
                 },
                 "spatialData": {
@@ -308,13 +324,34 @@ from simulariumio.constants import (
                         "1": {
                             "name": "B",
                             "geometry": {
+                                "displayType": "SPHERE",
                                 "color": "#0080ff",
                             },
                         },
-                        "2": {"name": "GRAY"},
-                        "3": {"name": "CYAN"},
-                        "4": {"name": "BLUE"},
-                        "5": {"name": "Link"},
+                        "2": {
+                            "name": "GRAY",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "3": {
+                            "name": "CYAN",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "4": {
+                            "name": "BLUE",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "5": {
+                            "name": "Link",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
                     },
                 },
                 "spatialData": {

--- a/simulariumio/tests/converters/test_trajectory_converter.py
+++ b/simulariumio/tests/converters/test_trajectory_converter.py
@@ -263,17 +263,72 @@ def mixed_agents_wrong_display_type2():
                         "fovDegrees": 60.0,
                     },
                     "typeMapping": {
-                        "0": {"name": "H"},
-                        "1": {"name": "A"},
-                        "2": {"name": "C"},
-                        "3": {"name": "X"},
-                        "4": {"name": "J"},
-                        "5": {"name": "L"},
-                        "6": {"name": "D"},
-                        "7": {"name": "U"},
-                        "8": {"name": "E"},
-                        "9": {"name": "Q"},
-                        "10": {"name": "K"},
+                        "0": {
+                            "name": "H",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "1": {
+                            "name": "A",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "2": {
+                            "name": "C",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "3": {
+                            "name": "X",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "4": {
+                            "name": "J",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "5": {
+                            "name": "L",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "6": {
+                            "name": "D",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "7": {
+                            "name": "U",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "8": {
+                            "name": "E",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "9": {
+                            "name": "Q",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "10": {
+                            "name": "K",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
                     },
                 },
                 "spatialData": {
@@ -586,12 +641,42 @@ def mixed_agents_wrong_display_type2():
                         "fovDegrees": DEFAULT_CAMERA_SETTINGS.FOV_DEGREES,
                     },
                     "typeMapping": {
-                        "0": {"name": "H"},
-                        "1": {"name": "A"},
-                        "2": {"name": "C"},
-                        "3": {"name": "L"},
-                        "4": {"name": "D"},
-                        "5": {"name": "K"},
+                        "0": {
+                            "name": "H",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "1": {
+                            "name": "A",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "2": {
+                            "name": "C",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "3": {
+                            "name": "L",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "4": {
+                            "name": "D",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "5": {
+                            "name": "K",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
                     },
                 },
                 "spatialData": {

--- a/simulariumio/tests/filters/test_every_nth_agent_filter.py
+++ b/simulariumio/tests/filters/test_every_nth_agent_filter.py
@@ -59,13 +59,48 @@ from simulariumio.constants import DEFAULT_CAMERA_SETTINGS, CURRENT_VERSION
                         "fovDegrees": DEFAULT_CAMERA_SETTINGS.FOV_DEGREES,
                     },
                     "typeMapping": {
-                        "0": {"name": "microtubule"},
-                        "1": {"name": "actin"},
-                        "2": {"name": "aster"},
-                        "3": {"name": "vesicle"},
-                        "4": {"name": "kinesin"},
-                        "5": {"name": "dynein"},
-                        "6": {"name": "motor complex"},
+                        "0": {
+                            "name": "microtubule",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "1": {
+                            "name": "actin",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "2": {
+                            "name": "aster",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "3": {
+                            "name": "vesicle",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "4": {
+                            "name": "kinesin",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "5": {
+                            "name": "dynein",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "6": {
+                            "name": "motor complex",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
                     },
                 },
                 "spatialData": {

--- a/simulariumio/tests/filters/test_every_nth_subpoint_filter.py
+++ b/simulariumio/tests/filters/test_every_nth_subpoint_filter.py
@@ -53,13 +53,48 @@ from simulariumio.constants import DEFAULT_CAMERA_SETTINGS, CURRENT_VERSION
                         "fovDegrees": DEFAULT_CAMERA_SETTINGS.FOV_DEGREES,
                     },
                     "typeMapping": {
-                        "0": {"name": "microtubule"},
-                        "1": {"name": "actin"},
-                        "2": {"name": "aster"},
-                        "3": {"name": "vesicle"},
-                        "4": {"name": "kinesin"},
-                        "5": {"name": "dynein"},
-                        "6": {"name": "motor complex"},
+                        "0": {
+                            "name": "microtubule",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "1": {
+                            "name": "actin",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "2": {
+                            "name": "aster",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "3": {
+                            "name": "vesicle",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "4": {
+                            "name": "kinesin",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "5": {
+                            "name": "dynein",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "6": {
+                            "name": "motor complex",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
                     },
                 },
                 "spatialData": {

--- a/simulariumio/tests/filters/test_every_nth_timestep_filter.py
+++ b/simulariumio/tests/filters/test_every_nth_timestep_filter.py
@@ -48,13 +48,48 @@ from simulariumio.constants import DEFAULT_CAMERA_SETTINGS, CURRENT_VERSION
                         "fovDegrees": DEFAULT_CAMERA_SETTINGS.FOV_DEGREES,
                     },
                     "typeMapping": {
-                        "0": {"name": "microtubule"},
-                        "1": {"name": "actin"},
-                        "2": {"name": "aster"},
-                        "3": {"name": "vesicle"},
-                        "4": {"name": "kinesin"},
-                        "5": {"name": "dynein"},
-                        "6": {"name": "motor complex"},
+                        "0": {
+                            "name": "microtubule",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "1": {
+                            "name": "actin",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "2": {
+                            "name": "aster",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "3": {
+                            "name": "vesicle",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "4": {
+                            "name": "kinesin",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "5": {
+                            "name": "dynein",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
+                        "6": {
+                            "name": "motor complex",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
                     },
                 },
                 "spatialData": {

--- a/simulariumio/tests/filters/test_multiply_space_filter.py
+++ b/simulariumio/tests/filters/test_multiply_space_filter.py
@@ -48,8 +48,18 @@ from simulariumio.constants import DEFAULT_CAMERA_SETTINGS, CURRENT_VERSION
                         "fovDegrees": DEFAULT_CAMERA_SETTINGS.FOV_DEGREES,
                     },
                     "typeMapping": {
-                        "0": {"name": "microtubule"},
-                        "1": {"name": "motor complex"},
+                        "0": {
+                            "name": "microtubule",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "1": {
+                            "name": "motor complex",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
                     },
                 },
                 "spatialData": {

--- a/simulariumio/tests/filters/test_multiply_time_filter.py
+++ b/simulariumio/tests/filters/test_multiply_time_filter.py
@@ -50,8 +50,18 @@ from simulariumio.constants import DEFAULT_CAMERA_SETTINGS, CURRENT_VERSION
                         "fovDegrees": DEFAULT_CAMERA_SETTINGS.FOV_DEGREES,
                     },
                     "typeMapping": {
-                        "0": {"name": "microtubule"},
-                        "1": {"name": "motor complex"},
+                        "0": {
+                            "name": "microtubule",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "1": {
+                            "name": "motor complex",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
                     },
                 },
                 "spatialData": {

--- a/simulariumio/tests/filters/test_transform_spatial_axes_filter.py
+++ b/simulariumio/tests/filters/test_transform_spatial_axes_filter.py
@@ -48,8 +48,18 @@ from simulariumio.constants import DEFAULT_CAMERA_SETTINGS, CURRENT_VERSION
                         "fovDegrees": DEFAULT_CAMERA_SETTINGS.FOV_DEGREES,
                     },
                     "typeMapping": {
-                        "0": {"name": "microtubule"},
-                        "1": {"name": "motor complex"},
+                        "0": {
+                            "name": "microtubule",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "1": {
+                            "name": "motor complex",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
                     },
                 },
                 "spatialData": {

--- a/simulariumio/tests/filters/test_translate_filter.py
+++ b/simulariumio/tests/filters/test_translate_filter.py
@@ -52,8 +52,18 @@ from simulariumio.constants import DEFAULT_CAMERA_SETTINGS, CURRENT_VERSION
                         "fovDegrees": DEFAULT_CAMERA_SETTINGS.FOV_DEGREES,
                     },
                     "typeMapping": {
-                        "0": {"name": "microtubule"},
-                        "1": {"name": "motor complex"},
+                        "0": {
+                            "name": "microtubule",
+                            "geometry": {
+                                "displayType": "FIBER",
+                            },
+                        },
+                        "1": {
+                            "name": "motor complex",
+                            "geometry": {
+                                "displayType": "SPHERE",
+                            },
+                        },
                     },
                 },
                 "spatialData": {


### PR DESCRIPTION
Problem
=======
Simulariumio only added "displayType" to .simularium files when something non-default was specified by the user
closes #71 

Solution
========
I modified `AgentData` so "displayType" is always added and defaults to either "SPHERE" or "FIBER" based on the number of subpoints the agent has.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires updated or new tests

Change summary:
---------------
* make sure any type in the mapping has geometry with displayType
* default to SPHERE or FIBER based on n_subpoints
* fix tests

Keyfiles:
-----------------------
1. simulariumio/data_objects/agent_data.py - add a `geometry` block with `displayType` in `get_type_ids_and_mapping()` if it isn't already
2. simulariumio/data_objects/display_data.py - add `check_set_default_display_type()` to set the displayType to the correct default if needed, always add "displayType" key to dict version
