### PR TITLE
Admin/document times

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Rendering capabilities planned for future:
 
 **Please note** that to run the Jupyter notebook examples you should also install Jupyter, either with `pip install jupyter`, or by installing SimulariumIO with the tutorial requirements: `pip install simulariumio[tutorial]`
 
+**Install time** depends on the speed of the connection and whether optional dependencies are included, but generally takes 30 seconds to a few minutes (see [benchmarks](benchmarks/README.md) for more details).
+
 
 <br/>
 
@@ -234,6 +236,8 @@ display_data={
     ),
 }
 ```
+
+**Conversion time** depends on hardware, the size of the input data, and which converter is used, but generally takes between less than a minute and five minutes (see [benchmarks](benchmarks/README.md) for more details).
 
 <br/>
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -19,4 +19,4 @@
   - Total time (including write to file) was ~5 minutes
 - 50MB SpringSaLaD file
   - Conversion ran in ~10 seconds
-  - Total time including write to file was ~45 seconds
+  - Total time (including write to file) was ~45 seconds

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,22 @@
+# Benchmark install time
+
+1. In a Python interpreter with a supported Python version ([see currently supported versions](../README.md#installation)), download and install SimulariumIO and all its dependencies by running `conda install readdy` and then `pip install simulariumio[all] --no-cache-dir`.
+
+### 11/18/21
+**Environment**: 2019 MacBook Pro, SimulariumIO 1.4.0, Python 3.9, 100 Mbps connection
+- With all dependencies (step #1 above): ~2.5 minutes
+- With only base dependencies (`pip install simulariumio --no-cache-dir`): ~20 seconds
+
+# Benchmark conversion time
+
+1. Unless you've already downloaded them, download benchmark files by running `download_benchmark_resources.py` in a Python interpreter with `simulariumio[benchmark]` installed. The files will be saved to `benchmarks/resources`.
+2. Run `benchmark_simulariumio.py` 
+
+### 11/18/21
+**Environment**: 2019 MacBook Pro, SimulariumIO 1.4.0, Python 3.9
+- 1GB Cytosim file
+  - Conversion ran in ~2.5 minutes
+  - Total time (including write to file) was ~5 minutes
+- 50MB SpringSaLaD file
+  - Conversion ran in ~10 seconds
+  - Total time including write to file was ~45 seconds

--- a/benchmarks/benchmark_simulariumio.py
+++ b/benchmarks/benchmark_simulariumio.py
@@ -7,12 +7,11 @@ import time
 
 import numpy as np
 
-from simulariumio import MetaData
+from simulariumio import MetaData, InputFileData, DisplayData, DISPLAY_TYPE
 from simulariumio.cytosim import (
     CytosimConverter,
     CytosimData,
     CytosimObjectInfo,
-    CytosimAgentInfo,
 )
 from simulariumio.springsalad import (
     SpringsaladConverter,
@@ -35,11 +34,25 @@ def convert_d_c_cytosim(input_path):
         ),
         object_info={
             "fibers": CytosimObjectInfo(
-                filepath=f"{input_path}/fiber_points.txt",
-                agents={
-                    1: CytosimAgentInfo(name="actin", radius=0.02),
-                    2: CytosimAgentInfo(name="myosin", radius=0.02),
-                    3: CytosimAgentInfo(name="myosinB", radius=0.02),
+                cytosim_file=InputFileData(
+                    file_path=f"{input_path}/fiber_points.txt",
+                ),
+                display_data={
+                    1: DisplayData(
+                        name="actin",
+                        radius=0.02,
+                        display_type=DISPLAY_TYPE.FIBER,
+                    ),
+                    2: DisplayData(
+                        name="myosin",
+                        radius=0.02,
+                        display_type=DISPLAY_TYPE.FIBER,
+                    ),
+                    3: DisplayData(
+                        name="myosinB",
+                        radius=0.02,
+                        display_type=DISPLAY_TYPE.FIBER,
+                    ),
                 },
             ),
         },
@@ -49,14 +62,27 @@ def convert_d_c_cytosim(input_path):
 
 def convert_condensate_springsalad(input_path):
     data = SpringsaladData(
-        path_to_sim_view_txt=f"{input_path}/Above_Ksp_viewer.txt",
-        display_names={
-            "ORANGE": "A Linker",
-            "MAGENTA": "A Binding site",
-            "GREEN": "B Binding site",
-            "PINK": "B Linker",
+        sim_view_txt_file=InputFileData(
+            file_path=f"{input_path}/Above_Ksp_viewer.txt",
+        ),
+        display_data={
+            "ORANGE": DisplayData(
+                name="A Linker",
+                display_type=DISPLAY_TYPE.SPHERE,
+            ),
+            "MAGENTA": DisplayData(
+                name="A Binding site",
+                display_type=DISPLAY_TYPE.SPHERE,
+            ),
+            "GREEN": DisplayData(
+                name="B Binding site",
+                display_type=DISPLAY_TYPE.SPHERE,
+            ),
+            "PINK": DisplayData(
+                name="B Linker",
+                display_type=DISPLAY_TYPE.SPHERE,
+            ),
         },
-        plots=[],
     )
     return SpringsaladConverter(data)
 

--- a/benchmarks/download_benchmark_resources.py
+++ b/benchmarks/download_benchmark_resources.py
@@ -32,7 +32,7 @@ class Args(argparse.Namespace):
             description=(
                 "Download files used for testing this project. This will download "
                 "all the required test resources and place them in the "
-                "`tests/resources` directory."
+                "`benchmarks/resources` directory."
             ),
         )
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ tutorial_requirements = [
 
 benchmark_requirements = [
     "awscli>=1.20"
-    "quilt3>=3.4",
+    "quilt3",
 ]
 
 dev_requirements = [


### PR DESCRIPTION
Problem
=======
Documentation was missing typical install and run times
closes #76 

Solution
========
I updated the benchmarks, ran them, and noted the approximate times on a new readme in benchmarks. I also added a statement about time for install and conversion on the main readme. This could all be nicer, but at least it provides some info about typical times.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

Change summary:
---------------
* remove quilt version pin since old versions aren't available, make sure quilt installs
* update benchmarks conversion to fix issues
* add benchmarks readme with results from running some quick tests
* add install and run times to main readme

Keyfiles:
-----------------------
1. README.md - add statements about install and convert times, with link to benchmarks readme
2. benchmarks/README.md - add readme with instructions for running benchmarks and some quick results
3. benchmarks/benchmark_simulariumio.py - updated input data for the benchmarks to use new `DisplayData` and `InputFileData`
4. setup.py - remove quilt version pin
