### PR TITLE
Fix writing to read-only array bug in nerdss_converter.py

### DIFF
--- a/simulariumio/nerdss/nerdss_converter.py
+++ b/simulariumio/nerdss/nerdss_converter.py
@@ -1,6 +1,8 @@
 from MDAnalysis import Universe
 import os
 
+import numpy as np
+
 from ..trajectory_converter import TrajectoryConverter
 from ..data_objects import (
     AgentData,
@@ -131,6 +133,10 @@ class NerdssConverter(TrajectoryConverter):
             "bonds", input_data.display_data
         )
         next_uid = agent_data.unique_ids.max() + 1
+
+        # need our own write-able n_subpoints array
+        n_subpoints = np.zeros_like(agent_data.n_subpoints)
+        
         for timestep in range(n_timesteps):
             n_fibers = len(fiber_positions[timestep])
             n_atoms = int(agent_data.n_agents[timestep])
@@ -139,7 +145,7 @@ class NerdssConverter(TrajectoryConverter):
                 agent_data.subpoints[timestep][agent_index + n_atoms] = fiber_positions[
                     timestep
                 ][agent_index]
-                agent_data.n_subpoints[timestep][agent_index + n_atoms] = (
+                n_subpoints[timestep][agent_index + n_atoms] = (
                     VALUES_PER_3D_POINT * 2
                 )
                 agent_data.viz_types[timestep][agent_index + n_atoms] = VIZ_TYPE.FIBER
@@ -149,6 +155,7 @@ class NerdssConverter(TrajectoryConverter):
                 agent_data.types[timestep].append(bonds_display_data.name)
                 agent_data.unique_ids[timestep][agent_index + n_atoms] = next_uid
                 next_uid += 1
+        agent_data.n_subpoints = n_subpoints # overwrite with our own array
         return agent_data
 
     def _read(self, input_data: NerdssData) -> TrajectoryData:


### PR DESCRIPTION
This pull request fixes a small bug in the NERDSS converter that was causing it to fail due to attempting to write to a read-only numpy array.

Time estimate or Size
=======
xsmall

Problem
=======
NERDSS trajectories were failing to convert to simularium format due to an issue within the NerdssConverter class where it tried to write to elements of a read-only numpy array.

Solution
========
Create a copy of the numpy array with the same shape, edit this array, then overwrite the original.

## Type of change
- Bug fix

Change summary:
---------------
* Fixed error "assignment destination is read-only" when calling NerdssConverter._read_pdb_files()

Steps to Verify:
----------------
1. Attempt to convert a NERDSS simulation using [ionerdss.convert_simularium()](https://github.com/JohnsonBiophysicsLab/ionerdss/blob/main/tutorials/ionerdss_tutorial_simularium.ipynb)

Keyfiles (delete if not relevant):
-----------------------
1. simulariumio/nerdss/nerdss_converter.py

