### PR TITLE
fixing ci, by explicitly adding pip to the conda environment.yml

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -23,7 +23,7 @@ clean:
 # install with all deps (and setup conda env with readdy)
 install:
 	conda env update --file environment.yml
-	pip install -e .[lint,test,docs,dev,mcell,physicell,md,cellpack,mem3dg,usd]
+	python -m pip install -e .[lint,test,docs,dev,mcell,physicell,md,cellpack,mem3dg,usd]
 
 # lint, format, and check all files
 lint:

--- a/environment.yml
+++ b/environment.yml
@@ -4,3 +4,4 @@ channels:
 dependencies:
   - readdy
   - numpy>=1.20
+  - pip


### PR DESCRIPTION
Time estimate or Size
=======
extra small

Problem
=======
CI has been broken due to a conda dependency install failure.  This is also holding back dependabot PRs as the builds are red.

Solution
========
Explicit add pip to the environment.yml.   Also explicitly run python interpreter from the justfile.


## Type of change

- Bug fix (non-breaking change which fixes an issue)

